### PR TITLE
add warnings for missing data #40

### DIFF
--- a/polarrouteserver/route_api/utils.py
+++ b/polarrouteserver/route_api/utils.py
@@ -267,7 +267,7 @@ def check_mesh_data(mesh: Mesh) -> str:
         # check for unexpected number of data files
         data_source_num_expected_files = expected_num_data_files.get(data_loader, None)
         if data_source_num_expected_files is not None:
-            actual_num_files = len(data_source[0]["params"]["files"])
+            actual_num_files = len([f for f in data_source[0]["params"]["files"] if f!=""]) # number of files removing empty strings
             if actual_num_files != data_source_num_expected_files:
                 message += f"{actual_num_files} of expected {data_source_num_expected_files} days' data available for {data_type}.\n"
 

--- a/polarrouteserver/route_api/utils.py
+++ b/polarrouteserver/route_api/utils.py
@@ -231,3 +231,37 @@ def select_mesh_for_route_evaluation(route: dict) -> Union[list[Mesh], None]:
     lons = [c[1] for c in coordinates]
 
     return select_mesh(min(lats), min(lons), max(lats), max(lons))
+
+    
+def check_mesh_data(mesh: Mesh) -> str:
+    """Check a mesh object for missing data sources. Return a warning message as a string."""
+
+    message = ""
+
+    mesh_data_sources = mesh.json['config']['mesh_info'].get('data_sources', None)
+
+    # check for completely absent data sources
+    if mesh_data_sources is None:
+        message = "Mesh has no data sources."
+        return message
+    
+    expected_sources = settings.EXPECTED_MESH_DATA_SOURCES
+    expected_num_data_files = settings.EXPECTED_MESH_DATA_FILES
+
+    for data_type, data_loader in expected_sources.items():
+        # check for missing individual data sources
+        data_source = [d for d in mesh_data_sources if d["loader"]==data_loader]
+        if len(data_source) == 0:
+            message += f"No {data_type} data available for this mesh.\n"
+
+            # skip to the next data source
+            continue
+
+        # check for unexpected number of data files
+        data_source_num_expected_files = expected_num_data_files.get(data_loader, None)
+        if data_source_num_expected_files is not None:
+            actual_num_files = len(data_source[0]["params"]["files"])
+            if actual_num_files != data_source_num_expected_files:
+                message += f"{actual_num_files} of expected {data_source_num_expected_files} days' data available for {data_type}.\n"
+
+    return message

--- a/polarrouteserver/route_api/utils.py
+++ b/polarrouteserver/route_api/utils.py
@@ -234,7 +234,14 @@ def select_mesh_for_route_evaluation(route: dict) -> Union[list[Mesh], None]:
 
     
 def check_mesh_data(mesh: Mesh) -> str:
-    """Check a mesh object for missing data sources. Return a warning message as a string."""
+    """Check a mesh object for missing data sources. 
+
+    Args:
+        mesh (Mesh): mesh object to evaluate.
+    
+    Returns:
+        A user-friendly warning message as a string.
+    """
 
     message = ""
 

--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -216,6 +216,9 @@ EXPECTED_MESH_DATA_SOURCES = {
 
 # number of data files expected in data_sources.params.files related by loader name as above, no need to include any of length 1 or 0
 EXPECTED_MESH_DATA_FILES = {
-    "amsr": 3,
+    "GEBCO": 1,
     "duacs_current": 3,
+    "amsr": 3,
+    "thickness": 0,
+    "density": 0,
 }

--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -204,3 +204,18 @@ base_routeplanner_config = {
 }
 TRAVELTIME_CONFIG = base_routeplanner_config | {"objective_function": "traveltime"}
 FUEL_CONFIG = base_routeplanner_config | {"objective_function": "fuel"}
+
+# dictionary relating user-friendly name of data source with loader value used in vessel mesh json 
+EXPECTED_MESH_DATA_SOURCES = {
+    "bathymetry": "GEBCO",
+    "current": "duacs_current",
+    "sea ice concentration": "amsr",
+    "thickness": "thickness",
+    "density": "density",
+}
+
+# number of data files expected in data_sources.params.files related by loader name as above, no need to include any of length 1 or 0
+EXPECTED_MESH_DATA_FILES = {
+    "amsr": 3,
+    "duacs_current": 3,
+}

--- a/polarrouteserver/settings/test.py
+++ b/polarrouteserver/settings/test.py
@@ -19,18 +19,3 @@ DATABASES = {
         "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     }
 }
-
-# dictionary relating user-friendly name of data source with loader value used in vessel mesh json 
-EXPECTED_MESH_DATA_SOURCES = {
-    "bathymetry": "GEBCO",
-    "current": "duacs_current",
-    "sea ice concentration": "amsr",
-    "thickness": "thickness",
-    "density": "density",
-}
-
-# number of data files expected in data_sources.params.files related by loader name as above, no need to include any of length 1 or 0
-EXPECTED_MESH_DATA_FILES = {
-    "amsr": 3,
-    "duacs_current": 3,
-}

--- a/polarrouteserver/settings/test.py
+++ b/polarrouteserver/settings/test.py
@@ -19,3 +19,18 @@ DATABASES = {
         "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     }
 }
+
+# dictionary relating user-friendly name of data source with loader value used in vessel mesh json 
+EXPECTED_MESH_DATA_SOURCES = {
+    "bathymetry": "GEBCO",
+    "current": "duacs_current",
+    "sea ice concentration": "amsr",
+    "thickness": "thickness",
+    "density": "density",
+}
+
+# number of data files expected in data_sources.params.files related by loader name as above, no need to include any of length 1 or 0
+EXPECTED_MESH_DATA_FILES = {
+    "amsr": 3,
+    "duacs_current": 3,
+}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,8 @@ import pytest
 from polarrouteserver.route_api.models import Mesh, Job, Route
 from polarrouteserver.route_api.utils import evaluate_route, route_exists, select_mesh, select_mesh_for_route_evaluation
 
+from polarrouteserver.route_api.models import Mesh, Route
+from polarrouteserver.route_api.utils import check_mesh_data, route_exists, select_mesh
 from .utils import add_test_mesh_to_db
 
 class TestRouteExists(TestCase):
@@ -270,3 +272,38 @@ def test_evaluate_route():
 
     result = evaluate_route(route_json, mesh[0])
     assert isinstance(result, dict)
+
+
+class TestMeshDataMessage(TestCase):
+
+    def test_no_missing_data_message(self):
+        mesh = add_test_mesh_to_db()
+        mesh.json['config']['mesh_info']['data_sources'] = [
+            {"loader": "GEBCO", "params": {"files": ["1"]}},
+            {"loader": "amsr", "params": {"files": ["1", "2", "3"]}},
+            {"loader": "duacs_current", "params": {"files": ["1", "2", "3"]}},
+            {"loader": "thickness"},
+            {"loader": "density"},
+        ]
+        assert check_mesh_data(mesh) == ""
+
+    def test_missing_data_message(self):
+        mesh = add_test_mesh_to_db()
+        mesh.json['config']['mesh_info']['data_sources'] = [
+            {"loader": "amsr", "params": {"files": ["1", "2", "3"]}},
+            {"loader": "duacs_current", "params": {"files": ["1", "2", "3"]}},
+            {"loader": "thickness"},
+            {"loader": "density"},
+        ]
+        assert check_mesh_data(mesh) == "No bathymetry data available for this mesh.\n"
+
+    def test_unexpected_data_length_message(self):
+        mesh = add_test_mesh_to_db()
+        mesh.json['config']['mesh_info']['data_sources'] = [
+            {"loader": "GEBCO"},
+            {"loader": "amsr", "params": {"files": ["1", "2"]}},
+            {"loader": "duacs_current", "params": {"files": ["1", "2", "3"]}},
+            {"loader": "thickness"},
+            {"loader": "density"},
+        ]
+        assert check_mesh_data(mesh) == "2 of expected 3 days' data available for sea ice concentration.\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -282,8 +282,8 @@ class TestMeshDataMessage(TestCase):
             {"loader": "GEBCO", "params": {"files": ["1"]}},
             {"loader": "amsr", "params": {"files": ["1", "2", "3"]}},
             {"loader": "duacs_current", "params": {"files": ["1", "2", "3"]}},
-            {"loader": "thickness"},
-            {"loader": "density"},
+            {"loader": "thickness", "params": {"files": [""]}},
+            {"loader": "density", "params": {"files": [""]}},
         ]
         assert check_mesh_data(mesh) == ""
 
@@ -292,18 +292,18 @@ class TestMeshDataMessage(TestCase):
         mesh.json['config']['mesh_info']['data_sources'] = [
             {"loader": "amsr", "params": {"files": ["1", "2", "3"]}},
             {"loader": "duacs_current", "params": {"files": ["1", "2", "3"]}},
-            {"loader": "thickness"},
-            {"loader": "density"},
+            {"loader": "thickness", "params": {"files": [""]}},
+            {"loader": "density", "params": {"files": [""]}},
         ]
         assert check_mesh_data(mesh) == "No bathymetry data available for this mesh.\n"
 
     def test_unexpected_data_length_message(self):
         mesh = add_test_mesh_to_db()
         mesh.json['config']['mesh_info']['data_sources'] = [
-            {"loader": "GEBCO"},
+            {"loader": "GEBCO", "params": {"files": ["1"]}},
             {"loader": "amsr", "params": {"files": ["1", "2"]}},
             {"loader": "duacs_current", "params": {"files": ["1", "2", "3"]}},
-            {"loader": "thickness"},
-            {"loader": "density"},
+            {"loader": "thickness", "params": {"files": [""]}},
+            {"loader": "density", "params": {"files": [""]}},
         ]
         assert check_mesh_data(mesh) == "2 of expected 3 days' data available for sea ice concentration.\n"


### PR DESCRIPTION
Resolves #40 

This PR adds warning messages to routes generated from meshes with missing datasets.
The expected datasets are configured in the settings file as well as the number of files expected.

Currently this doesn't provide any warnings over the dates of those data files, since this would depend on how those files are named, I think.