### PR TITLE
Serve schema and swagger ui alongside app

### DIFF
--- a/polarrouteserver/settings/base.py
+++ b/polarrouteserver/settings/base.py
@@ -87,6 +87,7 @@ INSTALLED_APPS = [
     "django_celery_results",
     "django_celery_beat",
     "drf_spectacular",
+    "drf_spectacular_sidecar",
     "polarrouteserver.route_api",
     "corsheaders",
 ]
@@ -116,7 +117,9 @@ SPECTACULAR_SETTINGS = {
     "TITLE": "PolarRoute-Server",
     "DESCRIPTION": "Backend server for serving PolarRoute and MeshiPhi assets",
     "VERSION": polarrouteserver_version,
-    "SERVE_INCLUDE_SCHEMA": False,
+    "SERVE_INCLUDE_SCHEMA": True,
+    "SWAGGER_UI_DIST": "SIDECAR",
+    "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
     "SECURITY": [],
     "AUTHENTICATION_WHITELIST": [],
 }

--- a/polarrouteserver/urls.py
+++ b/polarrouteserver/urls.py
@@ -17,11 +17,18 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from polarrouteserver.route_api import views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
     path(
         "api/route",
         views.RouteRequestView.as_view(),
@@ -61,6 +68,7 @@ urlpatterns = [
 # noqa
 try:
     from debug_toolbar.toolbar import debug_toolbar_urls
+
     urlpatterns += debug_toolbar_urls()
-except:#noqa
+except:  # noqa
     pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "django-celery-results",
     "django-cors-headers",
     "django-rest-framework",
-    "drf-spectacular",
+    "drf-spectacular[sidecar]",
     "haversine",
     "polar-route==1.0.0",
     "psycopg>=3",


### PR DESCRIPTION
Enables the DRF spectacular ability to serve the schema yaml at `/api/schema` and the swagger ui at `/api/schema/swagger-ui`.